### PR TITLE
Add support for Ollama, Palm, Claude-2, Cohere, Replicate Llama2 CodeLlama (100+LLMs) - using LiteLLM

### DIFF
--- a/demos/stacey/backend/llm/gpt.py
+++ b/demos/stacey/backend/llm/gpt.py
@@ -1,6 +1,7 @@
 # llm/gpt.py
 from typing import List, TypedDict
 
+import litellm
 import openai
 
 
@@ -20,8 +21,8 @@ class GPT:
         ])["content"]
 
     def create_conversation_completion(self, model, conversation: List[GptMessage]) -> GptMessage:
-        openai.api_key = self.api_key
-        chat_completion = openai.ChatCompletion.create(
+        litellm.api_key = self.api_key
+        chat_completion = litellm.completion(
             model=model,
             messages=conversation
         )


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 

Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```